### PR TITLE
Reduce WORKER_TIMEOUT from CRITICAL to ERROR

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -438,7 +438,7 @@ class Arbiter(object):
                 continue
 
             if not worker.aborted:
-                self.log.critical("WORKER TIMEOUT (pid:%s)", pid)
+                self.log.error("WORKER TIMEOUT (pid:%s)", pid)
                 worker.aborted = True
                 self.kill_worker(pid, signal.SIGABRT)
             else:


### PR DESCRIPTION
We treat `CRITICAL` logs as reason for alarm.
