### PR TITLE
remove unix domain socket on last arbiter exit

### DIFF
--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -4,6 +4,7 @@
 # See the NOTICE for more information.
 
 import errno
+import fcntl
 import os
 import socket
 import stat
@@ -100,6 +101,8 @@ class UnixSocket(BaseSocket):
                     raise ValueError("%r is not a socket" % addr)
         self.parent = os.getpid()
         super(UnixSocket, self).__init__(addr, conf, log, fd=fd)
+        # each arbiter grabs a shared lock on the unix socket.
+        fcntl.lockf(self.sock, fcntl.LOCK_SH | fcntl.LOCK_NB)
 
     def __str__(self):
         return "unix:%s" % self.cfg_addr
@@ -111,9 +114,17 @@ class UnixSocket(BaseSocket):
         os.umask(old_umask)
 
     def close(self):
-        super(UnixSocket, self).close()
         if self.parent == os.getpid():
-            os.unlink(self.cfg_addr)
+            # attempt to acquire an exclusive lock on the unix socket.
+            # if we're the only arbiter running, the lock will succeed, and
+            # we can safely rm the socket.
+            try:
+                fcntl.lockf(self.sock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except:
+                pass
+            else:
+                os.unlink(self.cfg_addr)
+        super(UnixSocket, self).close()
 
 
 def _sock_type(addr):

--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -52,7 +52,6 @@ class BaseSocket(object):
             self.sock.close()
         except socket.error as e:
             self.log.info("Error while closing socket %s", str(e))
-        time.sleep(0.3)
         del self.sock
 
 
@@ -99,6 +98,7 @@ class UnixSocket(BaseSocket):
                     os.remove(addr)
                 else:
                     raise ValueError("%r is not a socket" % addr)
+        self.parent = os.getpid()
         super(UnixSocket, self).__init__(addr, conf, log, fd=fd)
 
     def __str__(self):
@@ -112,7 +112,8 @@ class UnixSocket(BaseSocket):
 
     def close(self):
         super(UnixSocket, self).close()
-        os.unlink(self.cfg_addr)
+        if self.parent == os.getpid():
+            os.unlink(self.cfg_addr)
 
 
 def _sock_type(addr):

--- a/gunicorn/workers/geventlet.py
+++ b/gunicorn/workers/geventlet.py
@@ -42,11 +42,11 @@ def patch_sendfile():
 class EventletWorker(AsyncWorker):
 
     def patch(self):
+        hubs.use_hub()
         eventlet.monkey_patch(os=False)
         patch_sendfile()
 
     def init_process(self):
-        hubs.use_hub()
         self.patch()
         super(EventletWorker, self).init_process()
 
@@ -77,7 +77,11 @@ class EventletWorker(AsyncWorker):
 
         while self.alive:
             self.notify()
-            eventlet.sleep(1.0)
+            try:
+                eventlet.sleep(1.0)
+            except AssertionError:
+                self.alive = False
+                break
 
         self.notify()
         try:


### PR DESCRIPTION
pull in upstream close socket fix and only remove unix domain socket on last arbiter exit to keep the socket from being deleted during hot restarts
