### PR TITLE
add --delay-pidfile option for on the fly upgrades

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -121,7 +121,8 @@ class Arbiter(object):
         self.pid = os.getpid()
         if self.cfg.pidfile is not None:
             self.pidfile = Pidfile(self.cfg.pidfile)
-            self.pidfile.create(self.pid)
+            if not self.cfg.delay_pidfile:
+                self.pidfile.create(self.pid)
         self.cfg.on_starting(self)
 
         self.init_signals()
@@ -167,6 +168,8 @@ class Arbiter(object):
         util._setproctitle("master [%s]" % self.proc_name)
 
         self.manage_workers()
+        if self.cfg.delay_pidfile and self.pidfile is not None:
+            self.pidfile.create(self.pid)
         while True:
             try:
                 sig = self.SIG_QUEUE.pop(0) if len(self.SIG_QUEUE) else None

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -316,6 +316,9 @@ class Arbiter(object):
                     pass
 
             timeout = self.timeout - (time.time() - oldest)
+            # wake up every second if we're waiting on a delayed pidfile to be written
+            if self.pidfile is None and self.cfg.pidfile is not None and self.cfg.delay_pidfile:
+                timeout = 1.0
             # The timeout can be reached, so don't wait for a negative value
             timeout = max(timeout, 1.0)
         else:

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -495,11 +495,13 @@ class Arbiter(object):
             (pid, _) = workers.pop(0)
             self.kill_worker(pid, signal.SIGTERM)
 
+        # Use worker.start_time != worker.tmp.last_update() as a proxy for worker.boot,
+        # since worker.boot is only updated in the worker process
         if self.pidfile is None and self.cfg.pidfile is not None and self.cfg.delay_pidfile:
             worker_values = list(self.WORKERS.values())
             booted = True
             for worker in worker_values:
-                if not worker.booted:
+                if worker.tmp.last_update() == worker.start_time:
                     booted = False
                     break
             if booted:

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -871,6 +871,21 @@ class Pidfile(Setting):
         If not set, no PID file will be written.
         """
 
+class DelayPidfile(Setting):
+    name = "delay_pidfile"
+    section = "Server Mechanics"
+    cli = ["--delay-pidfile"]
+    validator = validate_bool
+    action = "store_true"
+    default = False
+    desc = """\
+        If pidfile is set, delay creation until workers have been spawned.
+
+        This setting is useful during on the fly upgrades as a mechanism for
+        signaling when a graceful shutdown of the old master process should be
+        initiated.
+        """
+
 class WorkerTmpDir(Setting):
     name = "worker_tmp_dir"
     section = "Server Mechanics"

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -879,7 +879,7 @@ class DelayPidfile(Setting):
     action = "store_true"
     default = False
     desc = """\
-        If pidfile is set, delay creation until workers have been spawned.
+        If pidfile is set, delay creation until workers have booted.
 
         This setting is useful during on the fly upgrades as a mechanism for
         signaling when a graceful shutdown of the old master process should be

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -47,6 +47,7 @@ class Worker(object):
         self.alive = True
         self.log = log
         self.tmp = WorkerTmp(cfg)
+        self.start_time = self.tmp.last_update()
 
     def __str__(self):
         return "<Worker %s>" % self.pid


### PR DESCRIPTION
rainbow-saddle waits on pidfile creation prior to TERMing the old arbiter.
