### PR TITLE
Discrete gunicorn workers

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -134,7 +134,7 @@ class Arbiter(object):
 	# self.cfg.worker_address is an optional parameter. Only create sockets if the value has been set. 
         if not self.WORKER_LISTENERS and self.cfg.worker_address :
             self.WORKER_LISTENERS = create_sockets(self.cfg,self.cfg.worker_address, self.log)
-            worker_listeners_str = ",".join([str(ws) for ws in self.WORKER_LISTENERS])
+            worker_listeners_str = ",".join([str(wl) for wl in self.WORKER_LISTENERS])
 
         listeners_str = ",".join([str(l) for l in self.LISTENERS])
         self.log.debug("Arbiter booted")
@@ -430,7 +430,7 @@ class Arbiter(object):
 	# worker_address defaults to []. Only create sockets if the list is not empty.
         if self.cfg.worker_address:
             self.WORKER_LISTENERS = create_sockets(self.cfg, self.cfg.worker_address, self.log)
-            self.log.info("Worker listening at: %s", ",".join([str(ws) for ws in self.WORKER_LISTENERS]))
+            self.log.info("Worker listening at: %s", ",".join([str(wl) for wl in self.WORKER_LISTENERS]))
 
         # do some actions on reload
         self.cfg.on_reload(self)

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -131,7 +131,7 @@ class Arbiter(object):
         if not self.LISTENERS:
             self.LISTENERS = create_sockets(self.cfg, self.cfg.address, self.log)
 
-    # self.cfg.worker_address is an optional parameter. Only create sockets if the value has been set.
+        # self.cfg.worker_address is an optional parameter. Only create sockets if the value has been set.
         if not self.WORKER_LISTENERS and self.cfg.worker_address :
             self.WORKER_LISTENERS = create_sockets(self.cfg,self.cfg.worker_address, self.log)
             worker_listeners_str = ",".join([str(wl) for wl in self.WORKER_LISTENERS])

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -381,7 +381,8 @@ class Arbiter(object):
             return
 
         environ = self.cfg.env_orig.copy()
-        fds = [l.fileno() for l in self.LISTENERS]
+        fds = [l.fileno() for l in self.LISTENERS + self.WORKER_LISTENERS]
+        self.log.debug("GUNICORN_FD is set to: %s", ",".join([str(fd) for fd in fds]))
         environ['GUNICORN_FD'] = ",".join([str(fd) for fd in fds])
 
         os.chdir(self.START_CTX['cwd'])

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -133,7 +133,7 @@ class Arbiter(object):
 
         # self.cfg.worker_address is an optional parameter. Only create sockets if the value has been set.
         if not self.WORKER_LISTENERS and self.cfg.worker_address :
-            self.WORKER_LISTENERS = create_sockets(self.cfg,self.cfg.worker_address, self.log)
+            self.WORKER_LISTENERS = create_sockets(self.cfg, self.cfg.worker_address, self.log)
             worker_listeners_str = ",".join([str(wl) for wl in self.WORKER_LISTENERS])
 
         listeners_str = ",".join([str(l) for l in self.LISTENERS])
@@ -543,7 +543,7 @@ class Arbiter(object):
         # When self.WORKER_SOCKETS is populated, we are to assign one worker listener per worker class.
         if self.WORKER_LISTENERS:
             listeners.append(self.WORKER_LISTENERS[self.worker_address_index])
-            self.worker_address_index = (self.worker_address_index + 1 )% len(self.WORKER_LISTENERS)
+            self.worker_address_index = (self.worker_address_index + 1) % len(self.WORKER_LISTENERS)
         worker = self.worker_class(self.worker_age, self.pid, listeners,
                                     self.app, self.timeout / 2.0,
                                     self.cfg, self.log)

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -11,7 +11,6 @@ import signal
 import sys
 import time
 import traceback
-import copy
 
 from gunicorn.errors import HaltServer, AppImportError
 from gunicorn.pidfile import Pidfile
@@ -545,6 +544,8 @@ class Arbiter(object):
         else:
             listeners = self.LISTENERS
         self.worker_age += 1
+        self.log.debug("Spawning worker of age: %d with the following listeners: %s",
+                       self.worker_age, ",".join([str(l) for l in listeners]))
         worker = self.worker_class(self.worker_age, self.pid, listeners,
                                     self.app, self.timeout / 2.0,
                                     self.cfg, self.log)

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -131,7 +131,7 @@ class Arbiter(object):
         if not self.LISTENERS:
             self.LISTENERS = create_sockets(self.cfg, self.cfg.address, self.log)
 
-	# self.cfg.worker_address is an optional parameter. Only create sockets if the value has been set. 
+    # self.cfg.worker_address is an optional parameter. Only create sockets if the value has been set.
         if not self.WORKER_LISTENERS and self.cfg.worker_address :
             self.WORKER_LISTENERS = create_sockets(self.cfg,self.cfg.worker_address, self.log)
             worker_listeners_str = ",".join([str(wl) for wl in self.WORKER_LISTENERS])
@@ -424,10 +424,10 @@ class Arbiter(object):
             self.log.info("Listening at: %s", ",".join([str(l) for l in self.LISTENERS]))
 
         # Clean up any worker listeners if it has changed
-	if old_worker_address != self.cfg.worker_address:
+        if old_worker_address != self.cfg.worker_address:
             # close all worker sockets
             [wl.close() for wl in self.WORKER_LISTENERS]
-	# worker_address defaults to []. Only create sockets if the list is not empty.
+        # worker_address defaults to []. Only create sockets if the list is not empty.
         if self.cfg.worker_address:
             self.WORKER_LISTENERS = create_sockets(self.cfg, self.cfg.worker_address, self.log)
             self.log.info("Worker listening at: %s", ",".join([str(wl) for wl in self.WORKER_LISTENERS]))
@@ -538,10 +538,10 @@ class Arbiter(object):
 
     def spawn_worker(self):
         self.worker_age += 1
-	# self.LISTENERS is the list of default sockets that workers listen on.
+        # self.LISTENERS is the list of default sockets that workers listen on.
         listeners = copy.copy(self.LISTENERS)
-	# When self.WORKER_SOCKETS is populated, we are to assign one worker listener per worker class.
-	if self.WORKER_LISTENERS:
+        # When self.WORKER_SOCKETS is populated, we are to assign one worker listener per worker class.
+        if self.WORKER_LISTENERS:
             listeners.append(self.WORKER_LISTENERS[self.worker_address_index])
             self.worker_address_index = (self.worker_address_index + 1 )% len(self.WORKER_LISTENERS)
         worker = self.worker_class(self.worker_age, self.pid, listeners,

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -121,6 +121,11 @@ class Config(object):
         return [util.parse_address(six.bytes_to_str(bind)) for bind in s]
 
     @property
+    def worker_address(self):
+        s = self.settings['domain_socket_per_worker'].get()
+        return [util.parse_address(six.bytes_to_str(ds)) for ds in s]
+
+    @property
     def uid(self):
         return self.settings['user'].get()
 
@@ -1680,3 +1685,15 @@ class SpawnWorkerSleepTime(Setting):
     desc = """\
     Minimum time to sleep between spawning workers. The value can be jittered up to 2x.
     """
+
+class DomainSocketPerWorker(Setting):
+    name = "domain_socket_per_worker"
+    action= "append"
+    section = 'Server Socket'
+    cli = ['--domain-socket-per-worker']
+    validator = validate_list_string
+    default = []
+    desc = '''\
+    When value is set with a list of addresses, each worker will be assigned one socket 
+    from the list in addition to the list of addresses specified in the parameter bind. 
+    '''

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1695,5 +1695,5 @@ class DomainSocketPerWorker(Setting):
     default = []
     desc = '''\
     When value is set with a list of addresses, each worker will be assigned one socket 
-    from the list in addition to the list of addresses specified in the parameter bind. 
+    from the list in addition to default addresses specfied by the parameter bind.
     '''

--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -175,7 +175,7 @@ def create_sockets(conf, address, log):
         del os.environ['LISTEN_PID'], os.environ['LISTEN_FDS']
 
         if listeners:
-	    log.debug('Socket activation sockets: %s',
+            log.debug('Socket activation sockets: %s',
                     ",".join([str(l) for l in listeners]))
             return listeners
 

--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -143,7 +143,7 @@ def _sock_type(addr):
     return sock_type
 
 
-def create_sockets(conf, log):
+def create_sockets(conf, address, log):
     """
     Create a new socket for the given address. If the
     address is a tuple, a TCP socket is created. If it
@@ -175,12 +175,12 @@ def create_sockets(conf, log):
         del os.environ['LISTEN_PID'], os.environ['LISTEN_FDS']
 
         if listeners:
-            log.debug('Socket activation sockets: %s',
+	    log.debug('Socket activation sockets: %s',
                     ",".join([str(l) for l in listeners]))
             return listeners
 
     # get it only once
-    laddr = conf.address
+    laddr = address
 
     # check ssl config early to raise the error on startup
     # only the certfile is needed since it can contains the keyfile


### PR DESCRIPTION
The addresses passed in through bind are viewed as the default sockets that all workers will listen on. If the param domain_socker_per_worker is set, we will rotate through those sockets for the workers. Each worker will listen on the default sockets to maintain functionality/expectations.
