### PR TITLE
ggeventpause tests and fixes

### DIFF
--- a/gunicorn/workers/ggeventpause.py
+++ b/gunicorn/workers/ggeventpause.py
@@ -155,6 +155,9 @@ class MozSvcGeventWorker(GeventWorker):
         """
         # Find the minimum interval between checks.
         sleep_interval = MAX_BLOCKING_TIME
+
+        logger.info("Starting pause detector for greenlets taking longer than %s seconds", MAX_BLOCKING_TIME)
+
         # Run the checks in an infinite sleeping loop.
         try:
             while not self._stop_event.isSet():
@@ -166,6 +169,8 @@ class MozSvcGeventWorker(GeventWorker):
             if sys is not None:
                 raise
         finally:
+            if logger:
+                logger.info("Pause detector is exiting")
             self._stopped_monitoring.set()
 
     def _check_greenlet_blocking(self):

--- a/gunicorn/workers/ggeventpause.py
+++ b/gunicorn/workers/ggeventpause.py
@@ -11,7 +11,7 @@ This module provides a custom GeventWorker subclass for gunicorn, with some
 extra operational niceties.
 """
 
-import logging
+import greenlet
 import os
 import signal
 import sys
@@ -21,7 +21,7 @@ import time
 import traceback
 
 import gevent.hub
-import greenlet
+from lyft import logging
 
 from gunicorn.workers.ggevent import GeventWorker
 
@@ -34,7 +34,7 @@ try:
 except ImportError:
     pass
 
-logger = logging.getLogger("mozsvc.gunicorn_worker")
+logger = logging.getLogger(__name__)
 
 # Take references to un-monkey-patched versions of stuff we need.
 # Monkey-patching will have already been done by the time we come to

--- a/gunicorn/workers/ggeventpause.py
+++ b/gunicorn/workers/ggeventpause.py
@@ -11,22 +11,25 @@ This module provides a custom GeventWorker subclass for gunicorn, with some
 extra operational niceties.
 """
 
-import os
-import sys
-import time
-import thread
-import signal
 import logging
+import os
+import signal
+import sys
+import thread
+import threading
+import time
 import traceback
 
-import greenlet
 import gevent.hub
+import greenlet
 
 from gunicorn.workers.ggevent import GeventWorker
+
 stats = None
 
 try:
     import statsd
+
     stats = statsd.StatsClient(prefix='gunicorn.worker')
 except ImportError:
     pass
@@ -38,8 +41,8 @@ logger = logging.getLogger("mozsvc.gunicorn_worker")
 # use these functions at runtime.
 _real_sleep = time.sleep
 _real_start_new_thread = thread.start_new_thread
+_real_event = threading.Event
 _real_get_ident = thread.get_ident
-
 
 # The maximum amount of time that the eventloop can be blocked
 # without causing an error to be logged.
@@ -79,7 +82,9 @@ class MozSvcGeventWorker(GeventWorker):
             # Set up a trace function to record each greenlet switch.
             self._active_greenlet = None
             self._greenlet_switch_counter = 0
-            greenlet.settrace(self._greenlet_switch_tracer)
+            # The settrace function returns the previous tracer
+            # We'll save it so we can call it after we are done tracing
+            self.previous_trace = greenlet.settrace(self._greenlet_switch_tracer)
             self._main_thread_id = _real_get_ident()
             needs_monitoring_thread = True
 
@@ -87,6 +92,8 @@ class MozSvcGeventWorker(GeventWorker):
         # Since this will be a long-running daemon thread, it's OK to
         # fire-and-forget using the low-level start_new_thread function.
         if needs_monitoring_thread:
+            self._stop_event = _real_event()
+            self._stopped_monitoring = _real_event()
             _real_start_new_thread(self._process_monitoring_thread, ())
 
         # Continue to superclass initialization logic.
@@ -106,7 +113,15 @@ class MozSvcGeventWorker(GeventWorker):
         with gevent.Timeout(self.cfg.timeout):
             return super(MozSvcGeventWorker, self).handle_request(*args)
 
-    def _greenlet_switch_tracer(self, what, (origin, target)):
+    def stop_monitoring(self, wait_timeout=10):
+        # Stops the thread monitoring for pause events
+        # If a timeout is specified, will wait up to that amount of time
+        # Returns True if the monitoring was stopped before the timeout
+        self._stop_event.set()
+        stopped = self._stopped_monitoring.wait(wait_timeout)
+        return stopped
+
+    def _greenlet_switch_tracer(self, event, args):
         """Callback method executed on every greenlet switch.
 
         The worker arranges for this method to be called on every greenlet
@@ -116,8 +131,19 @@ class MozSvcGeventWorker(GeventWorker):
         # Increment the counter to indicate that a switch took place.
         # This will periodically be reset to zero by the monitoring thread,
         # so we don't need to worry about it growing without bound.
-        self._active_greenlet = target
-        self._greenlet_switch_counter += 1
+
+        # For an explanation about why we look at these particular event types,
+        # see https://greenlet.readthedocs.io/en/latest/ [Tracing Support]
+        if event == 'switch' or event == 'throw':
+            origin, target = args
+            self._active_greenlet = target
+            self._greenlet_switch_counter += 1
+            self._last_switch_time = time.time()
+
+        # If there was a previously registered tracer,
+        # we can call it now
+        if self.previous_trace:
+            self.previous_trace(event, args)
 
     def _process_monitoring_thread(self):
         """Method run in background thread that monitors our execution.
@@ -131,7 +157,7 @@ class MozSvcGeventWorker(GeventWorker):
         sleep_interval = MAX_BLOCKING_TIME
         # Run the checks in an infinite sleeping loop.
         try:
-            while True:
+            while not self._stop_event.isSet():
                 _real_sleep(sleep_interval)
                 self._check_greenlet_blocking()
         except Exception:
@@ -139,6 +165,8 @@ class MozSvcGeventWorker(GeventWorker):
             # Daemonic Thread objects have this same behaviour.
             if sys is not None:
                 raise
+        finally:
+            self._stopped_monitoring.set()
 
     def _check_greenlet_blocking(self):
         if not MAX_BLOCKING_TIME:
@@ -153,10 +181,15 @@ class MozSvcGeventWorker(GeventWorker):
             if active_greenlet not in (None, self._active_hub):
                 frame = sys._current_frames()[self._main_thread_id]
                 stack = traceback.format_stack(frame)
-                err_log = ["Greenlet appears to be blocked\n"] + stack
+                time_running = time.time() - self._last_switch_time
+                err_message = "Greenlet appears to be blocked\n"
+                err_message += "It has been running over %.2f seconds (max time allowed is %s seconds)\n" % (
+                    time_running, MAX_BLOCKING_TIME)
+                err_log = [err_message] + stack
                 logger.error("".join(err_log))
                 if stats is not None:
                     stats.incr("paused")
+
         # Reset the count to zero.
         # This might race with it being incremented in the main thread,
         # but not often enough to cause a false positive.

--- a/gunicorn/workers/ggeventpause.py
+++ b/gunicorn/workers/ggeventpause.py
@@ -48,6 +48,11 @@ _real_get_ident = thread.get_ident
 # without causing an error to be logged.
 MAX_BLOCKING_TIME = float(os.environ.get("GEVENT_MAX_BLOCKING_TIME", 10))
 
+# Time at startup where we wont log pauses
+# Use to disable pause detection while the service loads
+# and reaches steady state
+WARMUP_TIME = float(os.environ.get("GEVENT_PAUSE_DETECTION_WARMUP_TIME", 10))
+
 
 class MozSvcGeventWorker(GeventWorker):
     """Custom gunicorn worker with extra operational niceties.
@@ -155,6 +160,9 @@ class MozSvcGeventWorker(GeventWorker):
         """
         # Find the minimum interval between checks.
         sleep_interval = MAX_BLOCKING_TIME
+
+        # give the service time to reach steady state
+        _real_sleep(WARMUP_TIME)
 
         logger.info("Starting pause detector for greenlets taking longer than %s seconds", MAX_BLOCKING_TIME)
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,3 +4,4 @@ pytest-cov==1.7.0
 sphinx
 sphinx_rtd_theme
 gevent
+lyft-stdlib==24.4.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,6 @@
-pytest==2.6.0
+pytest==2.8.5
+pytest-mock==0.9.0
 pytest-cov==1.7.0
 sphinx
 sphinx_rtd_theme
+gevent

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,6 @@
-pytest==2.8.5
-pytest-mock==0.9.0
+pytest>=2.8.5
+pytest-mock>=0.9.0
 pytest-cov==1.7.0
 sphinx
 sphinx_rtd_theme
 gevent
-lyft-stdlib==24.4.0

--- a/tests/test_011-ggeventpause.py
+++ b/tests/test_011-ggeventpause.py
@@ -1,0 +1,95 @@
+import os
+
+import gevent
+import greenlet
+import pytest
+from mock import MagicMock
+
+from gunicorn.config import Config
+from gunicorn.workers import ggeventpause
+
+MAX_BLOCK_TIME_SEC = 0.1
+
+
+def func_sleep(timeout=None):
+    ggeventpause._real_sleep(timeout)
+
+
+def func_sleep_over_max():
+    func_sleep(MAX_BLOCK_TIME_SEC * 3)
+
+
+def func_do_nothing():
+    pass
+
+
+@pytest.fixture
+def logger_mock(mocker):
+    return mocker.patch('gunicorn.workers.ggeventpause.logger')
+
+
+@pytest.yield_fixture
+@pytest.fixture
+def ggeventpause_worker(mocker):
+    # age, ppid, sockets, app, timeout, cfg, log)
+    ggeventpause.MAX_BLOCKING_TIME = MAX_BLOCK_TIME_SEC
+    app = MagicMock()
+    log = MagicMock()
+    worker = ggeventpause.MozSvcGeventWorker('age',
+                                             os.getppid(),
+                                             [],
+                                             app,
+                                             'timeout',
+                                             Config(),
+                                             log)
+
+    # We don't really want to run the gunicorn loop so mock it out
+    # Otherwise, init_process will start it and not return
+    run_mock = mocker.patch.object(worker, 'run')
+    worker.init_process()
+
+    yield worker
+
+    # Stop the worker from monitoring once we are done
+    # The assert is there to guarantee that the monitor was stopped
+    assert worker.stop_monitoring()
+
+
+@pytest.fixture
+def greenlet_tracer_mock(mocker):
+    tracer = MagicMock()
+    greenlet.settrace(tracer)
+    return tracer
+
+
+class MatchContainsString:
+    def __init__(self, substring):
+        self.substring = substring
+
+    def __eq__(self, strWithSubstring):
+        return strWithSubstring.find(self.substring) >= 0
+
+
+def test_logs_greenlets_over_max_time(mocker, ggeventpause_worker, logger_mock):
+    gevent.joinall([
+        gevent.spawn(func_sleep_over_max),
+        gevent.spawn(func_do_nothing),
+        gevent.spawn(lambda: func_sleep(MAX_BLOCK_TIME_SEC / 3))
+    ])
+
+    assert logger_mock.error.called
+    logger_mock.error.assert_called_with(MatchContainsString("func_sleep_over_max"))
+
+
+def test_calls_previous_tracers(mocker, greenlet_tracer_mock, ggeventpause_worker, logger_mock):
+    gevent.spawn(func_sleep_over_max).join()
+
+    assert greenlet_tracer_mock.called
+
+
+def test_stop_stops_monitoring(mocker, ggeventpause_worker, logger_mock):
+    ggeventpause_worker.stop_monitoring()
+
+    gevent.spawn(func_sleep_over_max).join()
+
+    assert not logger_mock.error.called


### PR DESCRIPTION
1. Add unit tests for ggeventpause
2. Add a stop_monitoring method to ggeventpause that stops the monitoring thread
3. Follow the greenlet.settrace guidelines for the tracer
4. Save and call any previous tracers so we play well with others
