### PR TITLE
Downgrade WORKER TIMEOUT from critical to error

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -483,7 +483,7 @@ class Arbiter(object):
                 continue
 
             if not worker.aborted:
-                self.log.critical("WORKER TIMEOUT (pid:%s)", pid)
+                self.log.error("WORKER TIMEOUT (pid:%s)", pid)
                 worker.aborted = True
                 self.kill_worker(pid, signal.SIGABRT)
             else:


### PR DESCRIPTION
This was done on the `lyft_19.60_fixes` branch in https://github.com/lyft/gunicorn/commit/3a77c85158eeb0e99486a10abe3a72bf21f61e98 but didn't make it to this branch (there was another commit with the same name but different change in https://github.com/lyft/gunicorn/commit/2f8979eae8098d39802bdaebbc6caae0ad375b96)

Slack thread for more context:
https://lyft.slack.com/archives/C3BLDHN92/p1555525607006600